### PR TITLE
Fix CI_SPEC_OPTIONS

### DIFF
--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -94,7 +94,7 @@ task :parallel_spec_standalone do |_t, args|
   else
     begin
       args = ['-t', 'rspec']
-      args += ENV['CI_SPEC_OPTIONS'].strip.split(' ') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?k
+      args += ENV['CI_SPEC_OPTIONS'].strip.split(' ') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
       args += Rake::FileList[pattern].to_a
 
       ParallelTests::CLI.new.run(args)

--- a/lib/puppetlabs_spec_helper/rake_tasks.rb
+++ b/lib/puppetlabs_spec_helper/rake_tasks.rb
@@ -94,8 +94,8 @@ task :parallel_spec_standalone do |_t, args|
   else
     begin
       args = ['-t', 'rspec']
-      args.push('--').concat(ENV['CI_SPEC_OPTIONS'].strip.split(' ')).push('--') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?
-      args.concat(Rake::FileList[pattern].to_a)
+      args += ENV['CI_SPEC_OPTIONS'].strip.split(' ') unless ENV['CI_SPEC_OPTIONS'].nil? || ENV['CI_SPEC_OPTIONS'].strip.empty?k
+      args += Rake::FileList[pattern].to_a
 
       ParallelTests::CLI.new.run(args)
     end


### PR DESCRIPTION
If I run `env CI_SPEC_OPTIONS="-n3 --serialize-stdout" bundle exec rake parallel_spec` I got an error:

```
4 processes for 81 specs, ~ 20 specs per process
invalid option: -3

Please use --help for a listing of valid options
invalid option: -3

Please use --help for a listing of valid options
invalid option: -3

Please use --help for a listing of valid options
invalid option: -3

Please use --help for a listing of valid options
```


I printed args:

```
"-t",
 "rspec",
 "--",
 "-n3",
 "--serialize-stdout",
 "--",
 "spec/classes/profiles/docker/config_spec.rb",
…
```

I think we don't need to push `--` elements